### PR TITLE
fix: handler init

### DIFF
--- a/src/ain.ts
+++ b/src/ain.ts
@@ -28,7 +28,9 @@ export default class AinModule {
   createAccount() {
     this.checkAinInitiated();
     const newAccount = this.ain!.wallet.create(1)[0];
-    return newAccount;
+    const wallet = this.ain!.wallet.accounts[newAccount];
+    this.ain!.wallet.remove(newAccount);
+    return wallet;
   }
 
   setDefaultAccount(privateKey: string) {

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -3,11 +3,11 @@ import Ain from "@ainblockchain/ain-js";
 import Ainize from "../ainize";
 import { Path } from "../constants";
 import AinModule from "../ain";
-import EventManager from "@ainblockchain/ain-js/lib/event-manager";
 
 export default class Handler {
   private static instance: Handler | undefined;
-  em = AinModule.getInstance().getEventManager();
+  ain = AinModule.getInstance();
+
   static getInstance() {
     if(!Handler.instance){
       Handler.instance = new Handler();
@@ -16,18 +16,15 @@ export default class Handler {
   }
 
   checkEventManager() {
-    if (!this.em) {
-      if(!AinModule.getInstance().getEventManager()){
-        throw new Error('you should init ain first');
-      }
-      this.em = AinModule.getInstance().getEventManager();
+    if(!AinModule.getInstance().getEventManager()){
+      throw new Error('you should init ain first');
     }
     return true;
   }
 
   async connect() {
     this.checkEventManager();
-    await this.em!.connect({},this.disconnectedCb);
+    await this.ain.getEventManager().connect({},this.disconnectedCb);
     console.log('connected');
   };
 
@@ -39,7 +36,7 @@ export default class Handler {
   async subscribe(requester:string, recordId:string, appName: string, resolve: any) {
     this.checkEventManager();
     const responsePath = Path.app(appName).response(requester, recordId);
-    const subscribeId = await this.em!.subscribe(
+    const subscribeId = await this.ain.getEventManager().subscribe(
       "VALUE_CHANGED",
       {
         path: responsePath,
@@ -57,7 +54,7 @@ export default class Handler {
 
   async unsubscribe(filterId: string) {
     this.checkEventManager();
-    await this.em!.unsubscribe(
+    await this.ain.getEventManager().unsubscribe(
       filterId,
       (err)=>{
         if (err) {


### PR DESCRIPTION
- handler에서 em을 static으로 선언하여 ain init이 되기 전 호출되어 에러가 발생하는 문제를 해결했습니다.
- createAccount시 account 정보 전체를 반환하고, 자동으로 등록된 생성된 account를 ain에서 삭제하는 코드를 추가했습니다.